### PR TITLE
Fix having software_id present for group mapping

### DIFF
--- a/group_mapping.py
+++ b/group_mapping.py
@@ -185,7 +185,7 @@ def _get_group_techniques(groups, stage, platform, file_type):
                     groups_dict[group_id]['weight'] = group['technique_id']
                 if campaign != '':
                     groups_dict[group_id]['campaign'] = str(campaign)
-                groups_dict[group_id]['software'] = group['software_id']
+                groups_dict[group_id]['software'] = group.get('software_id', None)
     else:
         # groups are provided as arguments via the command line
         all_groups_tech = load_attack_data(DATA_TYPE_CUSTOM_TECH_BY_GROUP)


### PR DESCRIPTION
- As noted in the wiki, `software_id` is not a hard requirement for the
  group mapping to work, however, it was previously not taking into
  account that `software_id` maybe empty when getting group details.