### PR TITLE
Upgrade attackcti to 0.3.6 and update revoked and deprecated functions

### DIFF
--- a/.github/workflows/scripts/refresh_attack_data.py
+++ b/.github/workflows/scripts/refresh_attack_data.py
@@ -42,12 +42,7 @@ class ATTACKData():
         self.data_source_dict_enterprise = self._create_data_source_dict(MATRIX_ENTERPRISE)
 
         self.attack_cti_techniques_enterprise = self.mitre.get_enterprise_techniques()
-        self.attack_cti_techniques_enterprise = self.mitre.remove_revoked(self.attack_cti_techniques_enterprise)
-        self.attack_cti_techniques_enterprise = self.mitre.remove_deprecated(self.attack_cti_techniques_enterprise)
-
         self.attack_cti_software = self.mitre.get_software()
-        self.attack_cti_software = self.mitre.remove_revoked(self.attack_cti_software)
-        self.attack_cti_software = self.mitre.remove_deprecated(self.attack_cti_software)
 
     def execute_refresh_json_data(self):
         """
@@ -279,12 +274,10 @@ class ATTACKData():
         ds_dict = {}
 
         cti_data_sources = self._get_data_sources_from_cti(matrix)
-        cti_data_sources = self.mitre.remove_revoked(cti_data_sources)
-        cti_data_sources = self.mitre.remove_deprecated(cti_data_sources)
+        cti_data_sources = self.mitre.remove_revoked_deprecated(cti_data_sources)
 
         cti_data_components = self._get_data_components_from_cti(matrix)
-        cti_data_components = self.mitre.remove_revoked(cti_data_components)
-        cti_data_components = self.mitre.remove_deprecated(cti_data_components)
+        cti_data_components = self.mitre.remove_revoked_deprecated(cti_data_components)
 
         for ds in cti_data_sources:
             name = ds['name']

--- a/.github/workflows/scripts/requirements_refresh_attack_data.txt
+++ b/.github/workflows/scripts/requirements_refresh_attack_data.txt
@@ -1,2 +1,2 @@
-attackcti==0.3.4.4
+attackcti==0.3.6
 taxii2-client==2.3.0

--- a/generic.py
+++ b/generic.py
@@ -139,12 +139,8 @@ def load_attack_data(data_type):
     attack_data = None
     if data_type == DATA_TYPE_STIX_ALL_RELATIONSHIPS:
         attack_data = mitre.get_relationships()
-        attack_data = mitre.remove_revoked(attack_data)
-        attack_data = mitre.remove_deprecated(attack_data)
     elif data_type == DATA_TYPE_STIX_ALL_TECH_ENTERPRISE:
         stix_attack_data = mitre.get_enterprise_techniques()
-        stix_attack_data = mitre.remove_revoked(stix_attack_data)
-        stix_attack_data = mitre.remove_deprecated(stix_attack_data)
         attack_data = _convert_stix_techniques_to_dict(stix_attack_data)
     elif data_type == DATA_TYPE_CUSTOM_TECH_BY_GROUP:
         # First we need to know which technique references (STIX Object type 'attack-pattern') we have for all
@@ -186,18 +182,12 @@ def load_attack_data(data_type):
 
     elif data_type == DATA_TYPE_STIX_ALL_TECH:
         stix_attack_data = mitre.get_techniques()
-        stix_attack_data = mitre.remove_revoked(stix_attack_data)
-        stix_attack_data = mitre.remove_deprecated(stix_attack_data)
         attack_data = _convert_stix_techniques_to_dict(stix_attack_data)
     elif data_type == DATA_TYPE_STIX_ALL_GROUPS:
         stix_attack_data = mitre.get_groups()
-        stix_attack_data = mitre.remove_revoked(stix_attack_data)
-        stix_attack_data = mitre.remove_deprecated(stix_attack_data)
         attack_data = _convert_stix_groups_to_dict(stix_attack_data)
     elif data_type == DATA_TYPE_STIX_ALL_SOFTWARE:
         attack_data = mitre.get_software()
-        attack_data = mitre.remove_revoked(attack_data)
-        attack_data = mitre.remove_deprecated(attack_data)
     elif data_type == DATA_TYPE_CUSTOM_TECH_BY_SOFTWARE:
         # First we need to know which technique references (STIX Object type 'attack-pattern') we have for all software
         # This results in a dict: {software_id: Sxxxx, technique_ref/attack-pattern_ref: ...}
@@ -263,13 +253,11 @@ def load_attack_data(data_type):
 
     elif data_type == DATA_TYPE_STIX_ALL_ENTERPRISE_MITIGATIONS:
         attack_data = mitre.get_enterprise_mitigations()
-        attack_data = mitre.remove_revoked(attack_data)
-        attack_data = mitre.remove_deprecated(attack_data)
+        attack_data = mitre.remove_revoked_deprecated(attack_data)
 
     elif data_type == DATA_TYPE_STIX_ALL_MOBILE_MITIGATIONS:
         attack_data = mitre.get_mobile_mitigations()
-        attack_data = mitre.remove_revoked(attack_data)
-        attack_data = mitre.remove_deprecated(attack_data)
+        attack_data = mitre.remove_revoked_deprecated(attack_data)
 
     # Only use cache when using online TAXII server:
     if local_stix_path is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-attackcti==0.3.4.4
+attackcti==0.3.6
 simplejson==3.17.6
 plotly==5.4.0
 pandas==1.3.5


### PR DESCRIPTION
Updated requirements attackcti to 0.3.6 (Fixes #60), remove revoked and deprecated functions and use new one (Fixes #61) and update functions that already remove revoked and deprecated STIX objects (Fixes #62).