### PR TITLE
Add detection score when generating technique administration file

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -158,12 +158,13 @@ YAML_OBJ_DETECTION = {'applicable_to': ['all'],
                           [
                               {'date': None,
                                'score': -1,
-                               'comment': ''}
+                               'comment': '',
+                                'auto_generated': True}
                       ]}
 
 YAML_OBJ_TECHNIQUE = {'technique_id': '',
                       'technique_name': '',
-                      'detection': YAML_OBJ_DETECTION,
+                      'detection': [],
                       'visibility': []}
 
 # EQL


### PR DESCRIPTION
The following command, give us a technique administration file, but only with a visibility score, not any detection score.
```
python dettect.py ds -fd sample-data/data-sources-endpoints.yaml --yaml
```
As long as there is no way to configure this score in the editor, by default to -1, I've added a way to use custom key-value pair, "detection_score" in this case, to specify a detection score.

It allows us to manage everything from the Data Sources panel in the editor.
Managing this score directly from Techniques panel was and still is possible, but it's longer because you need to edit every techniques one by one.
