### PR TITLE
datetime standards

### DIFF
--- a/editor/src/components/BaseTable.vue
+++ b/editor/src/components/BaseTable.vue
@@ -77,7 +77,7 @@
         }
         else if(value instanceof Date){
           // value = value;
-          value = moment(value, 'DD/MM/YYYY').format('YYYY-MM-DD');
+          value = moment.utc(value, 'DD/MM/YYYY').format('YYYY-MM-DD');
         }
 
         if(value == 'None') { value = '';}

--- a/editor/src/components/Inputs/DatePicker.vue
+++ b/editor/src/components/Inputs/DatePicker.vue
@@ -40,7 +40,7 @@ export default {
     methods: {
         updateDate(event) {
             // emit an event when the date changes and make sure the format is ok
-            let tmpDate = moment(event, 'DD/MM/YYYY').format('YYYY-MM-DD');
+            let tmpDate = moment.utc(event, 'DD/MM/YYYY').format('YYYY-MM-DD');
             if (tmpDate != 'Invalid date') {
                 this.$emit('dateUpdated', tmpDate);
             }

--- a/editor/src/pages/DataSourcesPage.vue
+++ b/editor/src/pages/DataSourcesPage.vue
@@ -356,10 +356,10 @@ export default {
                                 let dr = this.doc.data_sources[i].data_source[j]['date_registered'];
                                 let dv = this.doc.data_sources[i].data_source[j]['date_connected'];
                                 if (dr != null) {
-                                    this.doc.data_sources[i].data_source[j]['date_registered'] = moment(dr, 'DD/MM/YYYY').format('YYYY-MM-DD');
+                                    this.doc.data_sources[i].data_source[j]['date_registered'] = moment.utc(dr, 'DD/MM/YYYY').format('YYYY-MM-DD');
                                 }
                                 if (dv != null) {
-                                    this.doc.data_sources[i].data_source[j]['date_connected'] = moment(dv, 'DD/MM/YYYY').format('YYYY-MM-DD');
+                                    this.doc.data_sources[i].data_source[j]['date_connected'] = moment.utc(dv, 'DD/MM/YYYY').format('YYYY-MM-DD');
                                 }
                             }
                         }

--- a/editor/src/pages/TechniquesPage.vue
+++ b/editor/src/pages/TechniquesPage.vue
@@ -290,7 +290,7 @@ export default {
                                         yaml_input.techniques[i].detection[x].score_logbook[j].comment = '';
                                     }
                                     if (yaml_input.techniques[i].detection[x].score_logbook[j].date != null) {
-                                        yaml_input.techniques[i].detection[x].score_logbook[j].date = moment(
+                                        yaml_input.techniques[i].detection[x].score_logbook[j].date = moment.utc(
                                             yaml_input.techniques[i].detection[x].score_logbook[j].date,
                                             'DD/MM/YYYY'
                                         ).format('YYYY-MM-DD');
@@ -331,7 +331,7 @@ export default {
                                         yaml_input.techniques[i].visibility[x].score_logbook[j].comment = '';
                                     }
                                     if (yaml_input.techniques[i].visibility[x].score_logbook[j].date != null) {
-                                        yaml_input.techniques[i].visibility[x].score_logbook[j].date = moment(
+                                        yaml_input.techniques[i].visibility[x].score_logbook[j].date = moment.utc(
                                             yaml_input.techniques[i].visibility[x].score_logbook[j].date,
                                             'DD/MM/YYYY'
                                         ).format('YYYY-MM-DD');


### PR DESCRIPTION
There is an issue with repeated loading and saving of a yaml file that the time slow creeps forwards or backwards depending on the local time. The issue appears to be JS handling datetime as local (or without timezone) and moment working treating the times as UTC. This change forces moment to always convert to UTC anytime that datetime is written or read.