### PR TITLE
Fix health cache filename handling

### DIFF
--- a/health.py
+++ b/health.py
@@ -17,13 +17,17 @@ def _update_health_state(current, update):
         return update
 
 
+def _get_cache_file(prefix, filename):
+    return 'cache/' + prefix + os.path.splitext(os.path.basename(filename))[0]
+
+
 def _is_file_modified(filename):
     """
     Check if the provided file was modified since the last check
     :param filename: file location
     :return: true when modified else false
     """
-    last_modified_file = 'cache/last-modified_' + os.path.basename(filename).rstrip('.yaml')
+    last_modified_file = _get_cache_file('last-modified_', filename)
 
     def _update_modified_date(date):
         with open(last_modified_file, 'wb') as fd:
@@ -52,7 +56,7 @@ def _get_health_state_cache(filename):
     :param filename: file location
     :return: the cached error state
     """
-    last_error_file = 'cache/last-error-state_' + os.path.basename(filename).rstrip('.yaml')
+    last_error_file = _get_cache_file('last-error-state_', filename)
 
     if os.path.exists(last_error_file):
         with open(last_error_file, 'rb') as f:
@@ -69,7 +73,7 @@ def _update_health_state_cache(filename, has_error):
     # the function 'check_health_data_sources' will call this function without providing a filename when
     # 'check_health_data_sources' is called from '_events_to_yaml' within 'eql_yaml.py'
     if filename:
-        last_error_file = 'cache/last-error-state_' + os.path.basename(filename).rstrip('.yaml')
+        last_error_file = _get_cache_file('last-error-state_', filename)
 
         def _update(error):
             with open(last_error_file, 'wb') as fd:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from health import _is_file_modified, _update_health_state_cache
+
+
+class HealthCacheFilenameTest(unittest.TestCase):
+    def test_modified_cache_file_uses_yaml_stem(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                Path('cache').mkdir()
+                Path('my.yaml').write_text('content')
+
+                self.assertTrue(_is_file_modified('my.yaml'))
+
+                self.assertTrue(Path('cache/last-modified_my').exists())
+                self.assertFalse(Path('cache/last-modified_').exists())
+            finally:
+                os.chdir(cwd)
+
+    def test_error_state_cache_file_uses_yaml_stem(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                Path('cache').mkdir()
+                Path('normal.yaml').write_text('content')
+
+                _update_health_state_cache('normal.yaml', True)
+
+                self.assertTrue(Path('cache/last-error-state_normal').exists())
+                self.assertFalse(Path('cache/last-error-state_nor').exists())
+            finally:
+                os.chdir(cwd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi maintainers — thanks for the work on DeTTECT.

This fixes a small cache filename bug in `health.py`. The existing code used `rstrip('.yaml')`, which removes any trailing characters in that set rather than the `.yaml` suffix. That can create empty or truncated cache names for files like `my.yaml` or `normal.yaml`.

Changes:
- use `os.path.splitext()` when deriving health cache filenames
- add focused regression tests for modified-file and error-state cache paths

Validation:
- `python -m unittest tests.test_health -v`
- `python -m unittest discover -s tests -v`
- `python -m compileall -q .`
- `git diff --check`
