### PR TITLE
Escape editor notification messages

### DIFF
--- a/editor/src/components/NotificationPlugin/Notification.vue
+++ b/editor/src/components/NotificationPlugin/Notification.vue
@@ -24,7 +24,7 @@
             <div v-if="title" class="title">
                 <b>{{ title }}<br /></b>
             </div>
-            <div v-if="message" v-html="message"></div>
+            <div v-if="message">{{ message }}</div>
             <content-render v-if="!message && component" :component="component"></content-render>
             <div v-if="cb_function != null">
                 <a href="#" @click="cb_function(cb_function_key)">{{ cb_function_text }}</a>

--- a/tests/test_editor_notifications.py
+++ b/tests/test_editor_notifications.py
@@ -1,0 +1,14 @@
+import unittest
+from pathlib import Path
+
+
+class NotificationRenderingTest(unittest.TestCase):
+    def test_notification_messages_are_not_rendered_as_html(self):
+        notification = Path('editor/src/components/NotificationPlugin/Notification.vue').read_text()
+
+        self.assertNotIn('v-html="message"', notification)
+        self.assertIn('{{ message }}', notification)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi maintainers, thanks again for the work on DeTTECT.

This fixes a small client-side security issue in the editor notification component. Notification messages were rendered with `v-html`, so message text containing HTML could be interpreted by the browser. I checked the current notification call sites and did not find any notification messages that rely on HTML formatting, so this switches message rendering back to Vue's escaped text interpolation.

Changes:
- render notification `message` values as escaped text
- add a small regression test to keep `v-html` out of notification messages

Validation:
- `python -m unittest tests.test_editor_notifications -v`
- `python -m unittest discover -s tests -v`
- `python -m compileall -q tests/test_editor_notifications.py`
- `git diff --check`
- searched `editor/src` for `v-html`, no remaining matches

Note: I also tried to run the editor lint command, but dependency installation fails locally because `node-sass@6.0.1` does not build on Node.js 22. I have kept this PR limited to the notification rendering fix.
