### PR TITLE
Show dated negative detection comments in layers

### DIFF
--- a/navigator_layer.py
+++ b/navigator_layer.py
@@ -286,7 +286,8 @@ def add_metadata_technique_object(technique, obj_type, metadata, count_detection
 
     metadata.append({'divider': True})
     metadata.append({'name': 'Applicable to', 'value': ', '.join(set([a for v in technique[obj_type] for a in v['applicable_to']]))})  # noqa
-    metadata.append({'name': '' + obj_type.capitalize() + ' score', 'value': ', '.join([str(calculate_score(technique[obj_type]))])})  # noqa
+    score = calculate_score(technique[obj_type], zero_value=-1 if obj_type == 'detection' else 0)
+    metadata.append({'name': '' + obj_type.capitalize() + ' score', 'value': ', '.join([str(score)])})  # noqa
     if obj_type == 'detection':
         location = ''
         if count_detections:

--- a/technique_mapping.py
+++ b/technique_mapping.py
@@ -51,6 +51,21 @@ def _write_layer(layer, mapped_techniques, filename_prefix, name, output_filenam
     write_file(output_filename, output_overwrite, json_string)
 
 
+def _latest_score_is_nonnegative(yaml_object):
+    score = get_latest_score(yaml_object)
+    return score is not None and score >= 0
+
+
+def _include_detection_in_layer_metadata(detection):
+    """
+    Determine if a detection object should be represented in Navigator layer metadata.
+    Detection score -1 means not covered/not scored, but an explicitly dated assessment
+    still carries useful analyst context and should be visible in the matrix.
+    """
+    score = get_latest_score(detection)
+    return score is not None and (score >= 0 or (score == -1 and get_latest_date(detection) is not None))
+
+
 def _map_and_colorize_techniques_for_detections(my_techniques, domain, count_detections, layer_settings):
     """
     Determine the color of the techniques based on the detection score in the given YAML file. Also, it will create
@@ -81,25 +96,29 @@ def _map_and_colorize_techniques_for_detections(my_techniques, domain, count_det
             else:
                 tactics.append(None)
 
-            if s != -1:
+            include_technique = s != -1 or any(_include_detection_in_layer_metadata(d) for d in technique_data['detection'])
+
+            if include_technique:
                 color = COLOR_D_0 if s == 0 else COLOR_D_1 if s == 1 else COLOR_D_2 if s == 2 else COLOR_D_3 \
                     if s == 3 else COLOR_D_4 if s == 4 else COLOR_D_5 if s == 5 else ''
 
                 if technique is not None:
                     x = dict()
                     x['techniqueID'] = technique_id
-                    x['color'] = color
+                    if s != -1:
+                        x['color'] = color
                     x['comment'] = ''
                     x['enabled'] = True
                     x['metadata'] = []
-                    x['score'] = s
+                    if s != -1:
+                        x['score'] = s
 
                     if 'showMetadata' not in layer_settings.keys() or ('showMetadata' in layer_settings.keys() and str(layer_settings['showMetadata']) == 'True'):
                         cnt = 1
-                        tcnt = len([d for d in technique_data['detection'] if get_latest_score(d) >= 0])
+                        tcnt = len([d for d in technique_data['detection'] if _include_detection_in_layer_metadata(d)])
                         for detection in technique_data['detection']:
                             d_score = get_latest_score(detection)
-                            if d_score >= 0:
+                            if _include_detection_in_layer_metadata(detection):
                                 location = ''
                                 if count_detections:
                                     location_count = count_detections_in_location(detection['location'])
@@ -321,7 +340,10 @@ def _map_and_colorize_techniques_for_overlaid(my_techniques, platforms, domain, 
                                                                                                                                    applicable_dettect_data_sources))})
             # Metadata for detection and visibility:
             for obj_type in ['detection', 'visibility']:
-                tcnt = len([obj for obj in technique_data[obj_type] if get_latest_score(obj) >= 0])
+                if obj_type == 'detection':
+                    tcnt = len([obj for obj in technique_data[obj_type] if _include_detection_in_layer_metadata(obj)])
+                else:
+                    tcnt = len([obj for obj in technique_data[obj_type] if _latest_score_is_nonnegative(obj)])
                 if tcnt > 0:
                     x['metadata'] = add_metadata_technique_object(technique_data, obj_type, x['metadata'], count_detections)
 

--- a/tests/test_issue_57_negative_detection_comments.py
+++ b/tests/test_issue_57_negative_detection_comments.py
@@ -1,0 +1,85 @@
+import unittest
+from copy import deepcopy
+from datetime import datetime
+from unittest.mock import patch
+
+from technique_mapping import (
+    _map_and_colorize_techniques_for_detections,
+    _map_and_colorize_techniques_for_overlaid,
+)
+
+
+TECHNIQUE = {
+    'external_references': [{'source_name': 'mitre-attack', 'external_id': 'T1003'}],
+    'kill_chain_phases': [{'kill_chain_name': 'mitre-attack', 'phase_name': 'credential-access'}],
+    'data_components': [],
+    'dettect_data_sources': [],
+}
+
+BASE_DETECTION = {
+    'applicable_to': ['all'],
+    'location': ['SIEM: Rule 1'],
+    'comment': 'Technique level note',
+    'score_logbook': [{
+        'date': datetime(2022, 1, 7),
+        'score': -1,
+        'comment': 'Assessed, but no detection coverage yet',
+    }],
+}
+
+
+class NegativeDetectionScoreCommentsLayerTest(unittest.TestCase):
+    def _map_detection(self, detection):
+        techniques = {'T1003': {'detection': [detection]}}
+        with patch('technique_mapping.load_attack_data', return_value=[TECHNIQUE]):
+            return _map_and_colorize_techniques_for_detections(
+                techniques,
+                'enterprise-attack',
+                count_detections=False,
+                layer_settings={},
+            )
+
+    def _map_overlay(self, detection):
+        techniques = {'T1003': {'detection': [detection], 'visibility': []}}
+        with patch('technique_mapping.load_attack_data', return_value=[TECHNIQUE]):
+            return _map_and_colorize_techniques_for_overlaid(
+                techniques,
+                ['Windows'],
+                'enterprise-attack',
+                count_detections=False,
+                layer_settings={},
+            )
+
+    def test_negative_detection_score_with_date_is_included_without_visual_score(self):
+        mapped = self._map_detection(deepcopy(BASE_DETECTION))
+
+        self.assertEqual(1, len(mapped))
+        technique = mapped[0]
+        self.assertEqual('T1003', technique['techniqueID'])
+        self.assertNotIn('score', technique)
+        self.assertNotIn('color', technique)
+        self.assertIn(
+            {'name': 'Detection comment', 'value': 'Assessed, but no detection coverage yet'},
+            technique['metadata'],
+        )
+
+    def test_negative_detection_score_without_date_stays_hidden(self):
+        detection = deepcopy(BASE_DETECTION)
+        detection['score_logbook'][0]['date'] = None
+
+        self.assertEqual([], self._map_detection(detection))
+
+    def test_negative_detection_score_comment_is_included_in_overlay_metadata(self):
+        mapped = self._map_overlay(deepcopy(BASE_DETECTION))
+
+        self.assertEqual(1, len(mapped))
+        metadata = mapped[0]['metadata']
+        self.assertIn({'name': 'Detection score', 'value': '-1'}, metadata)
+        self.assertIn(
+            {'name': 'Detection score comment', 'value': 'Assessed, but no detection coverage yet'},
+            metadata,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi maintainers,

Thanks for keeping this open. This PR addresses issue #57 by making dated `-1` detection assessments visible in the Navigator layer metadata, without treating them as detection coverage.

## Summary

- Include detection techniques with a latest score of `-1` when the score object has a date.
- Preserve the analyst context in layer metadata, including the detection score comment.
- Do not set a Navigator `score` or `color` for these `-1` entries, so they remain informational rather than visually scored as coverage.
- Keep undated `-1` detections hidden, matching the distinction requested in the issue.
- Add a small stdlib `unittest` regression test for detection and overlay layer metadata.

## Validation

```bash
uv run --with-requirements requirements.txt python -m unittest discover -s tests -v
uv run --with-requirements requirements.txt python -m py_compile technique_mapping.py navigator_layer.py tests/test_issue_57_negative_detection_comments.py
git diff --check
```

All validation passed locally.

Closes #57
